### PR TITLE
Added support for mustache syntax highlighting inside of script blocks

### DIFF
--- a/syntax/mustache.vim
+++ b/syntax/mustache.vim
@@ -67,5 +67,9 @@ HtmlHiLink mustacheMarker Identifier
 HtmlHiLink mustacheError Error
 HtmlHiLink mustacheInsideError Error
 
+syn region mustacheScriptTemplate start=+<script [^>]*type *=[^>]*text/mustache[^>]*>+
+\                       end=+</script>+me=s-1 keepend
+\                       contains=mustacheError,mustacheInsideError,mustacheVariable,mustacheVariableUnescape,mustacheSection,mustachePartial,mustacheMarkerSet,mustacheComment,htmlHead,htmlTitle,htmlString,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlTag,htmlEndTag,htmlTagName,htmlSpecialChar,htmlLink
+
 let b:current_syntax = "mustache"
 delcommand HtmlHiLink


### PR DESCRIPTION
A number of mustache plugins seem to use <script> tags to embed mustache inside html, but by default these highlight as javascript rather than as mustache.  Added support for html
