### PR TITLE
Add .stache, .mstache, and .ms file extensions to match Coda plugin

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,3 +1,3 @@
 if has("autocmd")
-  au  BufNewFile,BufRead *.mustache,*.handlebars,*.hbs,*.hogan,*.hulk set filetype=mustache
+  au  BufNewFile,BufRead *.mustache,*.stache,*.mstache,*.ms,*.handlebars,*.hbs,*.hogan,*.hulk set filetype=mustache
 endif


### PR DESCRIPTION
The [Coda and SubEthaEdit plugin](https://github.com/bobthecow/Mustache.mode) supports the .stache, .mstache, and .ms file extensions in addition to the standard .mustache extension. I added them to this plugin to make files created with those extensions "auto-magically" work in Vim as well. Simple, but useful.
