### PR TITLE
Additional HTML container groups

### DIFF
--- a/syntax/mustache.vim
+++ b/syntax/mustache.vim
@@ -50,8 +50,7 @@ syntax region mustacheComment start=/{{!/ end=/}}/ contains=Todo containedin=htm
 
 " Clustering
 syntax cluster mustacheInside add=mustacheVariable,mustacheVariableUnescape,mustacheSection,mustachePartial,mustacheMarkerSet
-syntax cluster htmlMustacheContainer add=htmlHead,htmlTitle,htmlString,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
-
+syntax cluster htmlMustacheContainer add=htmlHead,htmlTitle,htmlString,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlLink,htmlBold,htmlUnderline,htmlItalic
 
 " Hilighting
 " mustacheInside hilighted as Number, which is rarely used in html
@@ -69,7 +68,7 @@ HtmlHiLink mustacheInsideError Error
 
 syn region mustacheScriptTemplate start=+<script [^>]*type *=[^>]*text/mustache[^>]*>+
 \                       end=+</script>+me=s-1 keepend
-\                       contains=mustacheError,mustacheInsideError,mustacheVariable,mustacheVariableUnescape,mustacheSection,mustachePartial,mustacheMarkerSet,mustacheComment,htmlHead,htmlTitle,htmlString,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlTag,htmlEndTag,htmlTagName,htmlSpecialChar,htmlLink
+\                       contains=mustacheError,mustacheInsideError,mustacheVariable,mustacheVariableUnescape,mustacheSection,mustachePartial,mustacheMarkerSet,mustacheComment,htmlHead,htmlTitle,htmlString,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlTag,htmlEndTag,htmlTagName,htmlSpecialChar,htmlLink,htmlBold,htmlUnderline,htmlItalic
 
 let b:current_syntax = "mustache"
 delcommand HtmlHiLink


### PR DESCRIPTION
First of all, thanks for making this plugin. I use it for working with `handlebars` and it works nice!

About this pull request: I've noticed that handlebars (or mustache) variables `{{ ... }}` aren't highlighted properly when inside `<a href....>{{ stuf }}</a>` tag. To be precise - they are highlighted as text within a html link (special + underline highlight).

The same happens within `<u>` and `<b>` and `<i>` tags.

From looking at the plugin source I got the impression that mustache/handlebars variables should have the highest syntax highlight priority. (at least they seem to have more priority than html header tags)

Hopefully, this pull request enables proper highlighting for handle./mustac. variables within `a`, `u`, `b` and `i` tags.

Let me know what you think?
