### PR TITLE
Add optional abbreviations for mustache

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@ Vim for Mustache and Handlebars
 ===============================
 
 mustache.vim is a simple plugin for working with mustache and handlebars
-templates. It has syntax highlighting and support for matchit.
+templates. It has:
+ - syntax highlighting,
+ - support for matchit and
+ - mustache abbreviations support (optional)
 
 
 ### Install for pathogen
@@ -19,6 +22,39 @@ templates. It has syntax highlighting and support for matchit.
     cp -R mustache.vim/ftdetect/* ~/.vim/ftdetect/
     cp -R mustache.vim/ftplugin/* ~/.vim/ftplugin/
     vim mustache.vim/example.mustache
+
+### Mustache Abbreviations
+
+You can activate mustache abbreviations by putting this line in your `.vimrc`:
+`let g:mustache_abbreviations = 1`
+
+Now you get a set of convenient abbreviations. Underscore `_` indicates where
+your cursor ends up after typing an abbreviation:
+ - `{{` => `{{_}}`
+ - `{{{` => `{{{_}}}`
+ - `{{!` => `{{!_}}`
+ - `{{>` => `{{>_}}`
+ - `{{<` => `{{<_}}`
+ - `{{#` produces
+
+   ```
+   {{# _}}
+   {{/}}
+   ```
+ - `{{if` produces
+
+   ```
+   {{#if _}}
+   {{/if}}
+   ```
+ - `{{ife` produces
+
+   ```
+   {{#if _}}
+   {{else}}
+   {{/if}}
+   ```
+
 
 ## Authors
 

--- a/ftplugin/mustache.vim
+++ b/ftplugin/mustache.vim
@@ -16,5 +16,18 @@ if exists("loaded_matchit") && exists("b:match_words")
   \ . '\%({{\)\@<=/\s*\1\s*}}'
 endif
 
+if exists("g:mustache_abbreviations")
+  inoremap <buffer> {{{ {{{}}}<left><left><left>
+  inoremap <buffer> {{ {{}}<left><left>
+  inoremap <buffer> {{! {{!}}<left><left>
+  inoremap <buffer> {{< {{<}}<left><left>
+  inoremap <buffer> {{> {{>}}<left><left>
+  inoremap <buffer> {{# {{#}}<cr>{{/}}<up><left><left>
+  inoremap <buffer> {{if {{#if }}<cr>{{/if}}<up><left>
+  inoremap <buffer> {{ife {{#if }}<cr>{{else}}<cr>{{/if}}<up><up><left>
+endif
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+" vim: nofoldenable


### PR DESCRIPTION
Hi @juvenn,
this pull request adds convenient, but completely optional abbreviations that help type mustache elements like `{{ }}` and `{{! }}`.

Let me know what you think of this!
