### PR TITLE
Section movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ templates. It has:
  - syntax highlighting,
  - support for matchit and
  - mustache abbreviations support (optional)
+ - support for section movement mappings `[[` and `]]`
 
 
 ### Install for pathogen
@@ -55,6 +56,17 @@ your cursor ends up after typing an abbreviation:
    {{/if}}
    ```
 
+### Section movement mappings
+
+Following the vim convention of jumping from section to section, `[[` and `]]`
+mappings are implemented for easier movement between mustache tags.
+
+ - `]]` jumps to the first following tag
+ - `[[` jumps to the first previous tag
+
+Count with section movements is supported:
+
+ - `2]]` jumps to the second next tag
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Count with section movements is supported:
 
 ## Authors
 
-* [bsutic](https://github.com/bsutic)
+* [bruno-](https://github.com/bruno-)
 * [juvenn](https://github.com/juvenn)
 
 Thanks [5long](https://github.com/5long) for adding matchit support.

--- a/ftplugin/mustache.vim
+++ b/ftplugin/mustache.vim
@@ -27,6 +27,36 @@ if exists("g:mustache_abbreviations")
   inoremap <buffer> {{ife {{#if }}<cr>{{else}}<cr>{{/if}}<up><up><left>
 endif
 
+
+" Section movement
+" Adapted from vim-ruby - many thanks to the maintainers of that plugin
+
+function! s:sectionmovement(pattern,flags,mode,count)
+  norm! m'
+  if a:mode ==# 'v'
+    norm! gv
+  endif
+  let i = 0
+  while i < a:count
+    let i = i + 1
+    " saving current position
+    let line = line('.')
+    let col  = col('.')
+    let pos = search(a:pattern,'W'.a:flags)
+    " if there's no more matches, return to last position
+    if pos == 0
+      call cursor(line,col)
+      return
+    endif
+  endwhile
+endfunction
+
+nnoremap <silent> <buffer> [[ :<C-U>call <SID>sectionmovement('{{','b','n',v:count1)<CR>
+nnoremap <silent> <buffer> ]] :<C-U>call <SID>sectionmovement('{{','' ,'n',v:count1)<CR>
+xnoremap <silent> <buffer> [[ :<C-U>call <SID>sectionmovement('{{','b','v',v:count1)<CR>
+xnoremap <silent> <buffer> ]] :<C-U>call <SID>sectionmovement('{{','' ,'v',v:count1)<CR>
+
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
 


### PR DESCRIPTION
Hi @juvenn,
this feature adds a conventional vim mappings `[[` and `]]` for moving between sections. In our case that is moving between mustache tags.

I know we're moving to a new repo soon, but until that is settled, I decided to make a pull req here.

Let me know what you think!
